### PR TITLE
-> Fixed Crash when using cropFaceByLeastAlgorithm(ref:git-issue#9)

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,1 +1,2 @@
 /build
+/src/main/java/com/darwin/sample/RegressionTestActivity.kt

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,6 +18,10 @@ android {
 
     buildTypes {
         release {
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+        debug {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }

--- a/app/src/main/java/com/darwin/sample/RegressionTestActivity.kt
+++ b/app/src/main/java/com/darwin/sample/RegressionTestActivity.kt
@@ -1,8 +1,11 @@
-package com.darwin.facedetector
+package com.darwin.sample
 
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.graphics.Matrix
+import android.media.ExifInterface
 import android.os.Bundle
+import android.os.Environment
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -14,20 +17,33 @@ import com.darwin.viola.still.model.FaceDetectionError
 import com.darwin.viola.still.model.FaceOptions
 import com.darwin.viola.still.model.Result
 import kotlinx.android.synthetic.main.activity_face_crop_sample.*
+import java.io.File
+import java.io.FileInputStream
+import java.io.IOException
 
-class FaceCropSampleActivity : AppCompatActivity() {
+/**
+ * The class StillImageSampleActivity
+ *
+ * @author Darwin Francis
+ * @version 1.0
+ * @since 13 Jul 2020
+ */
+class RegressionTestActivity : AppCompatActivity() {
 
     private lateinit var viola: Viola
     private lateinit var staggeredLayoutManager: StaggeredGridLayoutManager
     private val faceListAdapter = FacePhotoAdapter()
     private var bitmap: Bitmap? = null
     private var cropAlgorithm = CropAlgorithm.THREE_BY_FOUR
+    private var imageList: MutableList<Bitmap> = mutableListOf()
+    private var imageIndex = 0
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_face_crop_sample)
         initializeUI()
         setEventListeners()
+        listImagesFromFolder()
         prepareFaceCropper()
     }
 
@@ -55,14 +71,31 @@ class FaceCropSampleActivity : AppCompatActivity() {
         else -> CropAlgorithm.THREE_BY_FOUR
     }
 
+    private fun listImagesFromFolder() {
+        val path: String =
+            Environment.getExternalStorageDirectory().toString() + "/FImages"
+        val directory = File(path)
+        val files: Array<File> = directory.listFiles()
+        for (i in files.indices) {
+            try {
+                val f = File(files[i].name)
+                val options = BitmapFactory.Options()
+                options.inPreferredConfig = Bitmap.Config.ARGB_8888
+                val bitmap =
+                    BitmapFactory.decodeStream(FileInputStream("$path/$f"), null, options)
+                val rotBitmap = Util.modifyOrientation(bitmap!!, "$path/$f")
+                imageList.add(rotBitmap)
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        }
+    }
+
     private fun prepareFaceCropper() {
         viola = Viola(listener)
         val options = BitmapFactory.Options()
         options.inScaled = false
-        bitmap = BitmapFactory.decodeResource(
-            resources,
-            R.drawable.po_single, options
-        )
+        bitmap = imageList[0]
         iv_input_image.setImageBitmap(bitmap)
     }
 
@@ -70,21 +103,35 @@ class FaceCropSampleActivity : AppCompatActivity() {
         val faceOption =
             FaceOptions.Builder()
                 .cropAlgorithm(cropAlgorithm)
-                .setMinimumFaceSize(15)
+                .setMinimumFaceSize(4)
                 .enableDebug()
                 .build()
+
+        if (imageIndex < imageList.size) {
+            bitmap = imageList[imageIndex]
+
+            //bitmap = rotateBitmap(bitmap!!)
+
+            iv_input_image.setImageBitmap(bitmap)
+            viola.detectFace(bitmap!!, faceOption)
+            imageIndex++
+        } else {
+            imageIndex = 0
+        }
         viola.detectFace(bitmap!!, faceOption)
     }
+
 
     private val listener: FaceDetectionListener = object : FaceDetectionListener {
 
         override fun onFaceDetected(result: Result) {
+            tvErrorMessage.text = ""
             faceListAdapter.bindData(result.facePortraits)
         }
 
         override fun onFaceDetectionFailed(error: FaceDetectionError, message: String) {
             tvErrorMessage.text = message
+            faceListAdapter.bindData(listOf())
         }
     }
-
 }

--- a/app/src/main/java/com/darwin/sample/ViolaSampleActivity.kt
+++ b/app/src/main/java/com/darwin/sample/ViolaSampleActivity.kt
@@ -129,7 +129,7 @@ class ViolaSampleActivity : AppCompatActivity() {
         val faceOption =
             FaceOptions.Builder()
                 .cropAlgorithm(cropAlgorithm)
-                .setMinimumFaceSize(6)
+                //.setMinimumFaceSize(6)
                 .enableDebug()
                 .build()
         viola.detectFace(bitmap!!, faceOption)

--- a/still/build.gradle
+++ b/still/build.gradle
@@ -48,7 +48,7 @@ ext {
     libraryName = 'viola'     // this is the module name of library
     artifact = 'still'        // this is the artifact we want to see in implementation line
 
-    libraryDescription = 'Face detection library description' // description of library
+    libraryDescription = 'With Viola android face detection library, you can detect faces in a bitmap, crop faces using predefined algorithm and get additional information from the detected faces.' // description of library
 
     siteUrl = 'https://github.com/darwinfrancis/viola'    // git repo url
     gitUrl = 'https://github.com/darwinfrancis/viola.git' // git repo vcs url

--- a/still/src/main/java/com/darwin/viola/still/FaceAnalyser.kt
+++ b/still/src/main/java/com/darwin/viola/still/FaceAnalyser.kt
@@ -11,6 +11,7 @@ import com.google.mlkit.vision.face.Face
 import java.util.*
 import kotlin.math.sqrt
 
+
 /**
  * The class performs analysis on detected face and
  * crops according to desired cropping algorithm.
@@ -95,6 +96,7 @@ internal class FaceAnalyser {
                 croppedBitmap.height.toFloat(),
                 bitmap
             )
+
             val facePose = FacePose(
                 eulerValueToAngle(face.headEulerAngleX),
                 eulerValueToAngle(face.headEulerAngleY),
@@ -217,10 +219,13 @@ internal class FaceAnalyser {
 
         val heightTopOffset = (eyeDistance / 2).toInt()
         val heightBottomOffset = heightTopOffset / 2
-        val startX = face.boundingBox.left
+        var startX = face.boundingBox.left
         var startY = face.boundingBox.top - heightTopOffset
         var width = face.boundingBox.width()
         var height = face.boundingBox.height() + heightTopOffset + heightBottomOffset
+        if (startX < 0) {
+            startX = 0
+        }
         if (startY < 0) {
             startY = 0
         }


### PR DESCRIPTION
The bounding box from detected face may have negative coordinates, which results in invalid bitmap width and height.
Fixed issue by resetting x and y position to zero if it is negative.